### PR TITLE
Make pcdl install light weight by default

### DIFF
--- a/man/HOWTO.md
+++ b/man/HOWTO.md
@@ -9,6 +9,26 @@ Below you will find information about how to install, load, update, uninstall, a
 pip3 install pcdl
 ```
 
+This installs pcdl light weight: only the libraries needed to load PhysiCell
+output into pandas dataframes and to render basic contour and scatter plots
+(matplotlib, numpy, pandas, scipy).
+
+A handful of functions (`get_anndata`, `get_spatialdata`, `make_ome_tiff`,
+`make_conc_vtk`, `make_cell_vtk`, `render_neuroglancer`, `install_data`) rely
+on additional, heavyweight, specialized libraries (anndata, bioio,
+bioio-ome-tiff, geopandas, neuroglancer, requests, scikit-image, shapely,
+spatialdata, vtk) that are not installed by default. Calling one of these
+functions without the underlying library installed will raise an error that
+explains what is missing and how to install it. To install pcdl with all
+optional dependencies right away, run:
+
+```bash
+pip3 install pcdl[full]
+```
+
+Alternatively, install only the specific library a function's error message
+asks for, e.g. `pip3 install vtk`.
+
 
 ## How to load the pcdl library?
 

--- a/pcdl/_optional.py
+++ b/pcdl/_optional.py
@@ -1,0 +1,69 @@
+#########
+# title: _optional.py
+#
+# language: python3
+# date: 2026-08-14
+# license: BSD-3-Clause
+# author: Elmar Bucher
+#
+# description:
+#     pcdl, by default, only installs lightweight core dependencies
+#     (matplotlib, numpy, pandas, scipy), enough to load PhysiCell
+#     output into pandas dataframes, and to render basic contour and
+#     scatter plots.
+#     a handful of heavyweight, specialized libraries (anndata, bioio,
+#     bioio-ome-tiff, geopandas, neuroglancer, requests, scikit-image,
+#     shapely, spatialdata, vtk) are only needed by specific functions
+#     (e.g. get_anndata, get_spatialdata, make_ome_tiff, make_conc_vtk,
+#     make_cell_vtk, render_neuroglancer, install_data).
+#     optional_import loads such a library only the moment a function
+#     that actually needs it is called (lazy import), and raises a
+#     clear, actionable error message in case the library is missing.
+#########
+
+
+import importlib
+
+
+def optional_import(s_module, s_attr=None, s_pip=None, s_caller=None):
+    """
+    input:
+        s_module: string
+            dotted module path to import, e.g. 'anndata' or 'bioio.writers'.
+
+        s_attr: string; default None
+            if given, the attribute to fetch out of the imported module
+            (equivalent to "from s_module import s_attr").
+
+        s_pip: string; default None
+            pip install name for the module, if this differs from s_module
+            (e.g. s_module='skimage' but s_pip='scikit-image').
+            if None, the first dot-separated part of s_module is used.
+
+        s_caller: string; default None
+            name of the calling pcdl function, to mention in the error message.
+
+    output:
+        the imported module, or, if s_attr is given, the requested attribute
+        of the imported module.
+
+    description:
+        helper function to lazily load an optional, heavyweight pcdl
+        dependency, only the moment a function that actually needs it
+        is called. if the library is not installed, a ModuleNotFoundError
+        with an actionable error message is raised, pointing the user to
+        `pip install pcdl[full]` or to install the missing library manually.
+    """
+    s_pip = s_module.split('.')[0] if (s_pip is None) else s_pip
+    try:
+        o_module = importlib.import_module(s_module)
+    except ImportError as e:
+        s_fct = f' {s_caller}' if not (s_caller is None) else ''
+        raise ModuleNotFoundError(
+            f"Error{s_fct} : this functionality requires the optional dependency '{s_pip}', which is not installed.\n" +
+            f"pcdl was installed light weight (default), without this and other heavyweight, specialized libraries.\n" +
+            f"to fix this, either:\n" +
+            f"+ install pcdl with all optional dependencies: pip install pcdl[full]\n" +
+            f"+ or install only the missing library manually: pip install {s_pip}\n"
+        ) from e
+    return o_module if (s_attr is None) else getattr(o_module, s_attr)

--- a/pcdl/neuromancer.py
+++ b/pcdl/neuromancer.py
@@ -39,13 +39,22 @@
 
 # library
 import argparse
-from bioio import BioImage
 import matplotlib as mpl
-import neuroglancer
-import neuroglancer.cli
 import numpy as np
-from skimage import exposure, util
 import sys
+from pcdl._optional import optional_import
+
+# bue 2026-08-14: bioio, neuroglancer, and scikit-image are heavyweight,
+# specialized libraries, not part of the default, light weight pcdl
+# installation. this module only gets imported (from pcdl.timestep and
+# pcdl.timeseries) the moment render_neuroglancer actually is called, so
+# it is fine to eagerly, but lazily (from the caller's perspective), load
+# them here, with an actionable error message in case they are missing.
+BioImage = optional_import('bioio', s_attr='BioImage', s_pip='bioio', s_caller='pcdl.render_neuroglancer')
+neuroglancer = optional_import('neuroglancer', s_caller='pcdl.render_neuroglancer')
+optional_import('neuroglancer.cli', s_caller='pcdl.render_neuroglancer')  # binds neuroglancer.cli as attribute
+exposure = optional_import('skimage.exposure', s_pip='scikit-image', s_caller='pcdl.render_neuroglancer')
+util = optional_import('skimage.util', s_pip='scikit-image', s_caller='pcdl.render_neuroglancer')
 
 
 # functions

--- a/pcdl/output_data.py
+++ b/pcdl/output_data.py
@@ -23,7 +23,7 @@
 import os
 import pathlib
 import pcdl
-import requests
+from pcdl._optional import optional_import
 import shutil
 import tarfile
 
@@ -40,6 +40,9 @@ class install_data:
         function to install a 2D and 3D PhysiCell output test dataset.
     """
     def __init__(self):
+        # load optional dependency
+        requests = optional_import('requests', s_caller='pcdl.install_data')
+
         # get pcdl library installation path
         s_path = str(pathlib.Path(pcdl.__file__).parent).replace('\\','/') + '/'
 

--- a/pcdl/timeseries.py
+++ b/pcdl/timeseries.py
@@ -16,19 +16,22 @@
 
 
 # load libraries
-import anndata as ad
-import bioio_base
-from bioio.writers import OmeTiffWriter
 import glob
 import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pandas as pd
 from pcdl import render_neuroglancer
+from pcdl._optional import optional_import
 from pcdl.timestep import TimeStep, es_coor_cell, es_coor_conc, _anndextract
 from pcdl.VERSION import __version__
 import platform
 import sys
+
+# bue 2026-08-14: anndata and bioio are heavyweight, specialized libraries,
+# only needed by get_anndata and make_ome_tiff. to keep the default pcdl
+# installation light weight, these libraries are lazy loaded, via
+# optional_import, from within the functions that actually need them.
 
 
 ############
@@ -1176,6 +1179,9 @@ class TimeSeries:
 
         # output 11 ometiff file
         elif (file and collapse):  # 11
+            OmeTiffWriter = optional_import('bioio.writers', s_attr='OmeTiffWriter', s_pip='bioio', s_caller='TimeSeries.make_ome_tiff')
+            bioio_base = optional_import('bioio_base', s_pip='bioio', s_caller='TimeSeries.make_ome_tiff')
+
             a_tczyx_img = np.array(l_tczyx_img)
             if self.verbose:
                 print('a_tczyx_img shape:', a_tczyx_img.shape)
@@ -1661,6 +1667,9 @@ class TimeSeries:
             function to transform mcds time steps into one or many
             anndata objects for downstream analysis.
         """
+        # load optional dependency
+        ad = optional_import('anndata', s_caller='TimeSeries.get_anndata')
+
         # initialize vaiable
         l_annmcds = []
         df_anncount = None

--- a/pcdl/timestep.py
+++ b/pcdl/timestep.py
@@ -15,10 +15,6 @@
 
 
 # load library
-import anndata as ad
-import bioio_base
-from bioio.writers import OmeTiffWriter
-import geopandas as gpd
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from matplotlib import colors
@@ -26,23 +22,26 @@ try:
     import muspan as ms
 except ModuleNotFoundError:
     ms = None
-import networkx as nx
-import neuroglancer
 import numpy as np
 import os
 import pandas as pd
 from pcdl import imagine
 from pcdl import pdplt
-from pcdl import neuromancer
+from pcdl._optional import optional_import
 from scipy import io
 from scipy import sparse
-import shapely
-import spatialdata as sd
 import sys
-import vtk
 import warnings
 import xml.etree.ElementTree as etree
 from pcdl.VERSION import __version__
+
+# bue 2026-08-14: anndata, bioio, bioio_base, geopandas, networkx,
+# neuroglancer, shapely, spatialdata, and vtk are heavyweight, specialized
+# libraries, only needed by a handful of functions (get_anndata,
+# get_spatialdata, get_muspan, make_ome_tiff, make_conc_vtk, make_cell_vtk,
+# render_neuroglancer). to keep the default pcdl installation light weight,
+# these libraries are lazy loaded, via optional_import, from within the
+# functions that actually need them.
 
 
 # const physicell codec
@@ -223,6 +222,10 @@ def render_neuroglancer(tiffpathfile, timestep=0, intensity_cmap='gray'):
         function to load a time step from an ome tiff files, generated
         with make_ome_tiff, into neuroglancer.
     """
+    # load optional dependencies (neuromancer itself lazy loads bioio and scikit-image)
+    neuroglancer = optional_import('neuroglancer', s_caller='pcdl.render_neuroglancer')
+    from pcdl import neuromancer
+
     # start neuroglancer
     viewer = neuroglancer.Viewer()
     with viewer.txn() as state:
@@ -1404,6 +1407,9 @@ class TimeStep:
 
             https://www.paraview.org/
         """
+        # load optional dependency
+        vtk = optional_import('vtk', s_caller='TimeStep.make_conc_vtk')
+
         # off we go.
         s_vtkfile = self.xmlfile.replace('.xml', ext)
         if self.verbose:
@@ -1896,6 +1902,9 @@ class TimeStep:
 
             https://www.paraview.org/
         """
+        # load optional dependency
+        vtk = optional_import('vtk', s_caller='TimeStep.make_cell_vtk')
+
         # off we go.
         s_vtkfile = self.xmlfile.replace('.xml', ext)
         if self.verbose:
@@ -2031,6 +2040,11 @@ class TimeStep:
             https://napari.org/stable/
             https://fiji.sc/
         """
+        # load optional dependencies
+        if file:
+            OmeTiffWriter = optional_import('bioio.writers', s_attr='OmeTiffWriter', s_pip='bioio', s_caller='TimeStep.make_ome_tiff')
+            bioio_base = optional_import('bioio_base', s_pip='bioio', s_caller='TimeStep.make_ome_tiff')
+
         # handle channels
         ls_substrate = self.get_substrate_list()
         ls_celltype = self.get_celltype_list()
@@ -2404,6 +2418,9 @@ class TimeStep:
             function to transform a mcds time step into an anndata object
             for downstream analysis.
         """
+        # load optional dependency
+        ad = optional_import('anndata', s_caller='TimeStep.get_anndata')
+
         # processing
         if self.verbose:
             print(f'processing: 1/1 {round(self.get_time(),9)}[min] mcds into anndata obj.')
@@ -2479,6 +2496,12 @@ class TimeStep:
             function to transform a mcds time step into
             a spatialdata object for downstream analysis.
         """
+        # load optional dependencies
+        ad = optional_import('anndata', s_caller='TimeStep.get_spatialdata')
+        sd = optional_import('spatialdata', s_caller='TimeStep.get_spatialdata')
+        shapely = optional_import('shapely', s_caller='TimeStep.get_spatialdata')
+        gpd = optional_import('geopandas', s_caller='TimeStep.get_spatialdata')
+
         # set table spatial element links
         s_region_subs = None
         s_region_cell = None
@@ -2722,6 +2745,9 @@ class TimeStep:
         # check if muspan library is installed
         if ms is None:
             sys.exit(f'Error @ TimeStep.get_muspa : the muspan Multi Spatial Analysis python3 library is not installed!\nfor instructions check out : https://www.muspan.co.uk/')
+
+        # load optional dependency
+        nx = optional_import('networkx', s_caller='TimeStep.get_muspan')
 
         # get conc and cell dataframe
         df_conc = self.get_conc_df(values=values, drop=drop, keep=keep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,19 +69,30 @@ classifiers = [
 ]
 
 # bue 2024-12-06: enforcing some versions
+# bue 2026-08-14: default install is light weight: only the libraries
+# needed to load PhysiCell output into pandas dataframes and to render
+# basic contour and scatter plots. heavyweight, specialized libraries,
+# only needed for anndata, ome tiff, neuroglancer, muspan, vtk, and
+# spatialdata related functions, are bundled in the optional "full" extra.
+# run pip install pcdl[full] to install all of them at once, or install
+# a missing library manually, should a function ask for it at runtime.
 dependencies = [
+    "matplotlib",
+    "numpy",
+    "pandas>=2.2.2",
+    "scipy>=1.13.0",
+]
+
+[project.optional-dependencies]
+full = [
     "anndata>=0.10.8",
     "bioio>=2.0.0",
     "bioio-ome-tiff",
     "geopandas>=0.14",  # spatialdata
-    "matplotlib",
     "networkx",
     "neuroglancer",
-    "numpy",
-    "pandas>=2.2.2",
     "requests",
     "scikit-image>=0.24.0",
-    "scipy>=1.13.0",
     "shapely>=2.0.1",  # spatialdata
     "spatialdata>=0.7.2",
     "vtk",

--- a/test/test_optional_dependencies.py
+++ b/test/test_optional_dependencies.py
@@ -1,0 +1,242 @@
+#####
+# title: test_optional_dependencies.py
+#
+# language: python3
+# author: Elmar Bucher
+# date: 2026-08-14
+# license: BSD 3-Clause
+#
+# description:
+#   pytest unit test library that checks that pcdl installs and runs light
+#   weight (default install: matplotlib, numpy, pandas, scipy only), and
+#   that functions requiring an optional, heavyweight dependency (anndata,
+#   bioio, bioio-ome-tiff, geopandas, neuroglancer, requests, scikit-image,
+#   shapely, spatialdata, vtk) raise an actionable error message, pointing
+#   to `pip install pcdl[full]`, or to install the missing library manually,
+#   in case that dependency is not installed.
+#   + https://docs.pytest.org/
+#####
+
+
+# load library
+import os
+import pathlib
+import pytest
+import subprocess
+import sys
+import pcdl
+from pcdl._optional import optional_import
+
+
+# const
+s_path_2d = str(pathlib.Path(pcdl.__file__).parent.resolve()/'output_2d')
+s_file_2d = 'output00000024.xml'
+
+
+## download test dataset ##
+if not os.path.exists(s_path_2d):
+    pcdl.install_data()
+
+
+## the module names optional_import has to reach for, per heavyweight,
+## specialized pcdl function.
+ls_optional_module = [
+    'anndata',
+    'bioio',
+    'bioio.writers',
+    'bioio_base',
+    'geopandas',
+    'neuroglancer',
+    'neuroglancer.cli',
+    'requests',
+    'skimage.exposure',
+    'skimage.util',
+    'shapely',
+    'spatialdata',
+    'vtk',
+]
+
+## pre-warm the import cache for all optional dependencies (if installed),
+## so that the missing-dependency tests below, which poison one module at
+## a time via sys.modules, only ever fail on the single library they
+## specifically poison, not on some sibling library that library depends
+## on internally (e.g. spatialdata depends on shapely and geopandas).
+for s_module in ls_optional_module:
+    try:
+        optional_import(s_module)
+    except ModuleNotFoundError:
+        pass
+
+
+########################################
+# pcdl._optional.optional_import tests #
+########################################
+
+class TestOptionalImport(object):
+    ''' tests for the pcdl._optional.optional_import lazy import helper. '''
+
+    def test_optional_import_module_present(self):
+        o_module = optional_import('os')
+        assert o_module is os
+
+    def test_optional_import_attr_present(self):
+        f_join = optional_import('os.path', s_attr='join')
+        assert f_join is os.path.join
+
+    def test_optional_import_module_missing(self):
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            optional_import('pcdl_not_a_real_dependency_xyz')
+        s_message = str(o_error.value)
+        assert 'pcdl_not_a_real_dependency_xyz' in s_message
+        assert 'pip install pcdl[full]' in s_message
+        assert 'pip install pcdl_not_a_real_dependency_xyz' in s_message
+
+    def test_optional_import_module_missing_custom_pip_name(self):
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            optional_import('skimage_not_a_real_dependency', s_pip='scikit-image')
+        s_message = str(o_error.value)
+        assert 'scikit-image' in s_message
+        assert 'pip install scikit-image' in s_message
+
+    def test_optional_import_module_missing_caller_named(self):
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            optional_import('pcdl_not_a_real_dependency_xyz', s_caller='TimeStep.get_anndata')
+        assert 'TimeStep.get_anndata' in str(o_error.value)
+
+
+###############################################
+# light weight import and core function tests #
+###############################################
+
+class TestLightWeightImport(object):
+    '''
+    tests, run in a subprocess with a clean sys.modules, that pcdl can be
+    imported, and that basic, core data loading functions work, even if
+    none of the optional, heavyweight libraries are installed.
+    '''
+
+    def test_pcdl_import_and_core_functions_without_optional_libraries(self):
+        s_script = f"""
+import sys
+for s_module in {ls_optional_module!r}:
+    sys.modules[s_module] = None
+import pcdl
+mcds = pcdl.TimeStep(
+    xmlfile={s_file_2d!r},
+    output_path={s_path_2d!r},
+    verbose=False,
+)
+df_cell = mcds.get_cell_df()
+df_conc = mcds.get_conc_df()
+assert df_cell.shape[0] > 0
+assert df_conc.shape[0] > 0
+ax = mcds.plot_scatter()
+ax = mcds.plot_contour('oxygen')
+print('LIGHT_IMPORT_OK')
+"""
+        o_result = subprocess.run([sys.executable, '-c', s_script], capture_output=True, text=True)
+        assert 'LIGHT_IMPORT_OK' in o_result.stdout, o_result.stderr
+
+
+#######################################################
+# optional dependency function error message tests #
+#######################################################
+
+class TestOptionalDependencyErrors(object):
+    ''' tests that heavyweight-dependency functions fail informatively if the dependency is missing. '''
+
+    mcds = pcdl.TimeStep(xmlfile=s_file_2d, output_path=s_path_2d, verbose=False)
+
+    def test_make_conc_vtk_missing_vtk(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'vtk', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.make_conc_vtk()
+        s_message = str(o_error.value)
+        assert 'vtk' in s_message
+        assert 'pcdl[full]' in s_message
+
+    def test_make_cell_vtk_missing_vtk(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'vtk', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.make_cell_vtk()
+        assert 'vtk' in str(o_error.value)
+
+    def test_get_anndata_missing_anndata(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'anndata', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.get_anndata()
+        s_message = str(o_error.value)
+        assert 'anndata' in s_message
+        assert 'pcdl[full]' in s_message
+
+    def test_get_spatialdata_missing_anndata(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'anndata', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.get_spatialdata(images=set(), points={'cell'}, shapes=set())
+        assert 'anndata' in str(o_error.value)
+
+    def test_get_spatialdata_missing_spatialdata(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'spatialdata', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.get_spatialdata(images=set(), points={'cell'}, shapes=set())
+        assert 'spatialdata' in str(o_error.value)
+
+    def test_get_spatialdata_missing_shapely(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'shapely', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.get_spatialdata(images=set(), points=set(), shapes={'cell'})
+        assert 'shapely' in str(o_error.value)
+
+    def test_get_spatialdata_missing_geopandas(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'geopandas', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.get_spatialdata(images=set(), points=set(), shapes={'cell'})
+        assert 'geopandas' in str(o_error.value)
+
+    def test_get_spatialdata_does_not_need_bioio(self, monkeypatch, mcds=mcds):
+        # get_spatialdata renders its own images (file=False), so it must
+        # not require the bioio ome tiff writer stack.
+        monkeypatch.setitem(sys.modules, 'bioio', None)
+        monkeypatch.setitem(sys.modules, 'bioio.writers', None)
+        monkeypatch.setitem(sys.modules, 'bioio_base', None)
+        sdata = mcds.get_spatialdata(images={'subs'}, points={'subs'}, shapes={'cell'})
+        assert str(type(sdata)).startswith("<class 'spatialdata")
+
+    def test_make_ome_tiff_file_missing_bioio(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'bioio.writers', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            mcds.make_ome_tiff(file=True)
+        s_message = str(o_error.value)
+        assert 'bioio' in s_message
+        assert 'pcdl[full]' in s_message
+
+    def test_make_ome_tiff_array_does_not_need_bioio(self, monkeypatch, mcds=mcds):
+        monkeypatch.setitem(sys.modules, 'bioio', None)
+        monkeypatch.setitem(sys.modules, 'bioio.writers', None)
+        monkeypatch.setitem(sys.modules, 'bioio_base', None)
+        a_img = mcds.make_ome_tiff(file=False)
+        assert a_img.shape[0] > 0
+
+    def test_render_neuroglancer_missing_neuroglancer(self, monkeypatch, mcds=mcds):
+        monkeypatch.delitem(sys.modules, 'pcdl.neuromancer', raising=False)
+        monkeypatch.setitem(sys.modules, 'neuroglancer', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            pcdl.render_neuroglancer('not_a_real_file.ome.tiff')
+        s_message = str(o_error.value)
+        assert 'neuroglancer' in s_message
+        assert 'pcdl[full]' in s_message
+
+    def test_render_neuroglancer_missing_bioio(self, monkeypatch, mcds=mcds):
+        monkeypatch.delitem(sys.modules, 'pcdl.neuromancer', raising=False)
+        monkeypatch.setitem(sys.modules, 'bioio', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            pcdl.render_neuroglancer('not_a_real_file.ome.tiff')
+        assert 'bioio' in str(o_error.value)
+
+    def test_install_data_missing_requests(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, 'requests', None)
+        with pytest.raises(ModuleNotFoundError) as o_error:
+            pcdl.install_data()
+        s_message = str(o_error.value)
+        assert 'requests' in s_message
+        assert 'pcdl[full]' in s_message


### PR DESCRIPTION
Made pcdl's default install light-weight, keeping only what's needed to load PhysiCell output into pandas and do basic plotting.

**Core (required) deps** — unchanged behavior: matplotlib, numpy, pandas, scipy (scipy stays required since `scipy.io.loadmat` is used unconditionally in the core `.mat` parsing path).

**Moved to `pcdl[full]` extra:** anndata, bioio, bioio-ome-tiff, geopandas, neuroglancer, networkx, requests, scikit-image, shapely, spatialdata, vtk, ome-zarr. (`networkx` and `ome-zarr` are new upstream deps as of this branch's base — `networkx` is only needed by the new `get_muspan`, so it got the same lazy-load treatment.)

**Implementation** (`pcdl/_optional.py`): a small `optional_import()` helper that lazily imports a module inside the function that needs it, raising a `ModuleNotFoundError` with an actionable message (`pip install pcdl[full]` or the specific missing package) if it's absent. Applied to every function that touched a heavy lib: `get_anndata`, `get_spatialdata`, `make_ome_tiff`, `make_conc_vtk`, `make_cell_vtk`, `render_neuroglancer`/`neuromancer.py`, `get_muspan` (networkx only — muspan itself already had its own no-hard-fail check), `install_data` — in both `timestep.py` and `timeseries.py`. As a bonus, `make_ome_tiff(file=False)` and `get_spatialdata()` no longer need `bioio` at all, since the numpy-array path never touches the OME-TIFF writer.

**Tests** (`test/test_optional_dependencies.py`, 19 tests): unit tests for the helper itself, a subprocess-based test that poisons all heavy libs in `sys.modules` and confirms `import pcdl` + core loading/plotting still works, and per-function tests confirming each heavy-dep method fails with the right actionable message when its library is missing (while unrelated core functionality keeps working).

**Verified:** fresh venv with only `pip install -e .` pulled in just matplotlib/numpy/pandas/scipy; core loading and plotting worked; calling `get_anndata()`, `make_conc_vtk()`, `install_data()` gave the friendly install-hint errors. Full existing suite (475 tests) passes. Also updated `man/HOWTO.md` with the new install story.

Note: this repo's own release notes show a similar "light install" split was tried once (v3.2.11) and reverted (v3.3.0) as "too confusing" — happy to discuss whether `pcdl[full]` is the right shape, or something more fine-grained is preferred.
